### PR TITLE
Create miniaturisationRTG.xml

### DIFF
--- a/Defs/MiniaturisationDefs/miniaturisationRTG.xml
+++ b/Defs/MiniaturisationDefs/miniaturisationRTG.xml
@@ -1,0 +1,10 @@
+<Defs>
+    <Miniaturisation.MiniaturisationDef>
+        <defName>MiniaturisationRTG</defName>
+        <requiredMod>RTGs v1.15</requiredMod>
+        <targetsDefNames>
+            <li>RTG</li>
+            <li>ASRG</li>
+        </targetsDefNames>
+    </Miniaturisation.MiniaturisationDef>
+</Defs>


### PR DESCRIPTION
adds support for itchyfleas RTG mod. the ASRG is 3x3 tiles big but then again the component bench is 2x4 or 5 tiles big and it can be re-installed anywhere, so i think the ASRG being re-installable is appropriate.

also, how do i update my fork so it is as recent as the main branch?
